### PR TITLE
Added Gaussian Latent Representations for Uncertainty Estimation usin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Table of Contents
 
 **Conference**
 
+- Gaussian Latent Representations for Uncertainty Estimation using Mahalanobis Distance in Deep Classifiers [[ICCV Workshop2023]](https://openaccess.thecvf.com/content/ICCV2023W/UnCV/papers/Venkataramanan_Gaussian_Latent_Representations_for_Uncertainty_Estimation_Using_Mahalanobis_Distance_in_ICCVW_2023_paper.pdf) - [[PyTorch]](<https://github.com/vaishwarya96/MAPLE-uncertainty-estimation>)
 - A Simple and Explainable Method for Uncertainty Estimation using Attribute Prototype Networks [[ICCV Workshop2023]](https://openaccess.thecvf.com/content/ICCV2023W/UnCV/papers/Zelenka_A_Simple_and_Explainable_Method_for_Uncertainty_Estimation_Using_Attribute_ICCVW_2023_paper.pdf)
 - Deep Deterministic Uncertainty: A Simple Baseline [[CVPR2023]](<https://arxiv.org/abs/2102.11582>) - [[PyTorch]](<https://github.com/omegafragger/DDU>)
 - Training, Architecture, and Prior for Deterministic Uncertainty Methods [[ICLR Workshop2023]](<https://arxiv.org/abs/2303.05796>) - [[PyTorch]](<https://github.com/orientino/dum-components>)


### PR DESCRIPTION
Added paper link and code for Gaussian Latent Representations for Uncertainty Estimation using Mahalanobis
Distance in Deep Classifiers published in ICCV Workshop 2023 under the topic "Deterministic Uncertainty Methods"